### PR TITLE
Use RetryExec(3) for helm repo add step

### DIFF
--- a/internal/app/helm_helpers.go
+++ b/internal/app/helm_helpers.go
@@ -200,7 +200,7 @@ func addHelmRepos(repos map[string]string) error {
 			}
 		}
 		cmd := helmCmd(concat([]string{"repo", "add", forceUpdateFlag, repoName, repoURL}, basicAuthArgs), "Adding helm repository [ "+repoName+" ]")
-		if _, err := cmd.Exec(); err != nil {
+		if _, err := cmd.RetryExec(3); err != nil {
 			return fmt.Errorf("while adding helm repository [%s]]: %w", repoName, err)
 		}
 	}


### PR DESCRIPTION
Depending on the helm repo availability, helm repo add step can be problematic when running helmsman in parallel. 
This can result with:
```
[2021-10-11T11:02:09.442Z] 2021-10-11 11:02:09 INFO: Setting up helm


[2021-10-11T11:02:10.352Z] 2021-10-11 11:02:10 CRITICAL: While adding helm repository [bitnami]: Error: looks like "https://charts.bitnami.com/bitnami" is not a valid chart repository or cannot be reached: stream error: stream ID 1; INTERNAL_ERROR
```

so the retry seems to be the easiest way to mitigate the issue same as we did for unexpected network connection interruptions when running helm upgrade commands.