### PR TITLE
Add namespaceLabelsAuthoritative settings option to allow removing undefined namespace's labels

### DIFF
--- a/docs/desired_state_specification.md
+++ b/docs/desired_state_specification.md
@@ -112,6 +112,7 @@ The following options can be skipped if your kubectl context is already created 
 - **slackWebhook** : a [Slack](http://slack.com) Webhook URL to receive Helmsman notifications. This can be passed directly or in an environment variable.
 - **msTeamsWebhook** : a [Microsoft Teams](https://www.microsoft.com/pl-pl/microsoft-teams/group-chat-software) Webhook URL to receive Helmsman notifications. This can be passed directly or in an environment variable.
 - **reverseDelete** : if set to `true` it will reverse the priority order whilst deleting.
+- **namespaceLabelsAuthoritative** : if set to `true` it will remove all the namespace's labels that are not defined in DSL for particular namespace
 - **eyamlEnabled** : if set to `true` it will use [hiera-eyaml](https://github.com/voxpupuli/hiera-eyaml) to decrypt secret files instead of using default helm-secrets based on sops
 - **eyamlPrivateKeyPath** : if set with path to the eyaml private key file, it will use it instead of looking for default one in ./keys directory relative to where Helmsman were run. It needs to be defined in conjunction with eyamlPublicKeyPath.
 - **eyamlPublicKeyPath** : if set with path to the eyaml public key file, it will use it instead of looking for default one in ./keys directory relative to where Helmsman were run. It needs to be defined in conjunction with eyamlPrivateKeyPath.

--- a/internal/app/decision_maker.go
+++ b/internal/app/decision_maker.go
@@ -102,7 +102,7 @@ func (cs *currentState) decide(r *release, n *namespace, p *plan, c *chartInfo) 
 
 	if flags.destroy {
 		if ok := cs.releaseExists(r, ""); ok {
-			p.addDecision("Release [ "+r.Name+" ] will be DELETED (destroy flag enabled).", r.Priority, delete)
+			p.addDecision("Release [ "+r.Name+" ] will be DELETED (destroy flag enabled).", r.Priority, remove)
 			r.uninstall(p)
 		}
 		return
@@ -110,7 +110,7 @@ func (cs *currentState) decide(r *release, n *namespace, p *plan, c *chartInfo) 
 
 	if !r.Enabled {
 		if ok := cs.releaseExists(r, ""); ok {
-			p.addDecision("Release [ "+r.Name+" ] is desired to be DELETED.", r.Priority, delete)
+			p.addDecision("Release [ "+r.Name+" ] is desired to be DELETED.", r.Priority, remove)
 			r.uninstall(p)
 		} else {
 			p.addDecision("Release [ "+r.Name+" ] disabled", r.Priority, noop)
@@ -275,7 +275,7 @@ func (cs *currentState) cleanUntrackedReleases(s *state, p *plan) {
 			if !tracked {
 				toDelete++
 				r := cs.releases[name+"-"+ns]
-				p.addDecision("Untracked release [ "+r.Name+" ] found and it will be deleted", -1000, delete)
+				p.addDecision("Untracked release [ "+r.Name+" ] found and it will be deleted", -1000, remove)
 				r.uninstall(p)
 			}
 		}

--- a/internal/app/decision_maker_test.go
+++ b/internal/app/decision_maker_test.go
@@ -317,8 +317,8 @@ func (dt decisionType) String() string {
 		return "create"
 	case change:
 		return "change"
-	case delete:
-		return "delete"
+	case remove:
+		return "remove"
 	case noop:
 		return "noop"
 	}

--- a/internal/app/plan.go
+++ b/internal/app/plan.go
@@ -16,7 +16,7 @@ type decisionType int
 const (
 	create decisionType = iota + 1
 	change
-	delete
+	remove
 	noop
 	ignored
 )
@@ -219,7 +219,7 @@ func (p *plan) print() {
 	for _, decision := range p.Decisions {
 		if decision.Type == ignored || decision.Type == noop {
 			log.Info(decision.Description + " -- priority: " + strconv.Itoa(decision.Priority))
-		} else if decision.Type == delete {
+		} else if decision.Type == remove {
 			log.Warning(decision.Description + " -- priority: " + strconv.Itoa(decision.Priority))
 		} else {
 			log.Notice(decision.Description + " -- priority: " + strconv.Itoa(decision.Priority))

--- a/internal/app/state.go
+++ b/internal/app/state.go
@@ -12,22 +12,23 @@ import (
 
 // config type represents the settings fields
 type config struct {
-	KubeContext         string                 `yaml:"kubeContext"`
-	Username            string                 `yaml:"username"`
-	Password            string                 `yaml:"password"`
-	ClusterURI          string                 `yaml:"clusterURI"`
-	ServiceAccount      string                 `yaml:"serviceAccount"`
-	StorageBackend      string                 `yaml:"storageBackend"`
-	SlackWebhook        string                 `yaml:"slackWebhook"`
-	MSTeamsWebhook      string                 `yaml:"msTeamsWebhook"`
-	ReverseDelete       bool                   `yaml:"reverseDelete"`
-	BearerToken         bool                   `yaml:"bearerToken"`
-	BearerTokenPath     string                 `yaml:"bearerTokenPath"`
-	EyamlEnabled        bool                   `yaml:"eyamlEnabled"`
-	EyamlPrivateKeyPath string                 `yaml:"eyamlPrivateKeyPath"`
-	EyamlPublicKeyPath  string                 `yaml:"eyamlPublicKeyPath"`
-	GlobalHooks         map[string]interface{} `yaml:"globalHooks"`
-	GlobalMaxHistory    int                    `yaml:"globalMaxHistory"`
+	KubeContext                  string                 `yaml:"kubeContext"`
+	Username                     string                 `yaml:"username"`
+	Password                     string                 `yaml:"password"`
+	ClusterURI                   string                 `yaml:"clusterURI"`
+	ServiceAccount               string                 `yaml:"serviceAccount"`
+	StorageBackend               string                 `yaml:"storageBackend"`
+	SlackWebhook                 string                 `yaml:"slackWebhook"`
+	MSTeamsWebhook               string                 `yaml:"msTeamsWebhook"`
+	ReverseDelete                bool                   `yaml:"reverseDelete"`
+	BearerToken                  bool                   `yaml:"bearerToken"`
+	BearerTokenPath              string                 `yaml:"bearerTokenPath"`
+	NamespaceLabelsAuthoritative bool                   `yaml:"namespaceLabelsAuthoritative"`
+	EyamlEnabled                 bool                   `yaml:"eyamlEnabled"`
+	EyamlPrivateKeyPath          string                 `yaml:"eyamlPrivateKeyPath"`
+	EyamlPublicKeyPath           string                 `yaml:"eyamlPublicKeyPath"`
+	GlobalHooks                  map[string]interface{} `yaml:"globalHooks"`
+	GlobalMaxHistory             int                    `yaml:"globalMaxHistory"`
 }
 
 // state type represents the desired state of applications on a k8s cluster.


### PR DESCRIPTION
This adds `namespaceLabelsAuthoritative` option in `settings` block in DSF file, so when enabled, it will remove all the labels of the namespace that are not defined in DSF for this particular namespace. It's totally optional but there are use cases where authoritative control over it is needed.

FYI: I had to change deicsionType from delete to remove as this was shadowing built-in delete function I used.