### PR TITLE
feat: Add option to verify charts before using them

### DIFF
--- a/docs/cmd_reference.md
+++ b/docs/cmd_reference.md
@@ -120,4 +120,7 @@ This lists available CMD options in Helmsman:
   `--check-for-chart-updates`
         compares the chart versions in the state file to the latest versions in the chart repositories and shows available updates
 
+  `--verify`
+        verify if charts are signed and valid before using them
+
   `--v`    show the version.

--- a/internal/app/cli.go
+++ b/internal/app/cli.go
@@ -99,6 +99,7 @@ type cli struct {
 	skipPendingApps       bool
 	pendingAppRetries     int
 	showSecrets           bool
+	verify                bool
 }
 
 func printUsage() {
@@ -157,6 +158,7 @@ func (c *cli) setup() {
 	flag.BoolVar(&c.skipPendingApps, "skip-pending", false, "skip pending helm releases")
 	flag.IntVar(&c.pendingAppRetries, "pending-max-retries", 0, "max number of retries for pending helm releases")
 	flag.BoolVar(&c.showSecrets, "show-secrets", false, "show helm diff results with secrets.")
+	flag.BoolVar(&c.verify, "verify", false, "verify if charts are signed and valid before using them")
 	flag.Usage = printUsage
 	flag.Parse()
 }

--- a/internal/app/release.go
+++ b/internal/app/release.go
@@ -412,6 +412,10 @@ func (r *Release) getHelmFlags() []string {
 		flgs = append(flgs, "--force")
 	}
 
+	if flags.verify {
+		flgs = append(flgs, "--verify")
+	}
+
 	return concat(r.getNoHooks(), r.getWait(), r.getTimeout(), r.getMaxHistory(), flags.getRunFlags(), r.HelmFlags, flgs)
 }
 


### PR DESCRIPTION
Summary

This pull request reintroduces the `--verify` flag functionality to the Helmsman project. The `--verify` flag enables verification of downloaded charts during install/update operations. The implementation has been rewritten for improved simplicity and reliability.

When the `--verify` flag is set:
- A provenance file must be present for each chart.
- The provenance file must successfully pass all verification checks.

Related PRs: #953, #946 
cc: @rvbcia
