### PR TITLE
Automatically generate release notes with goreleaser and conventional cmmits

### DIFF
--- a/.commitlintrc.yaml
+++ b/.commitlintrc.yaml
@@ -1,0 +1,7 @@
+extends:
+  - '@commitlint/config-conventional'
+rules:
+  type-enum:
+    - 2
+    - always
+    - [feat, fix, chore]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,19 @@ on:
     branches: [master]
 
 jobs:
+  commitlint:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: wagoid/commitlint-github-action@v6
+
   test:
+    needs: commitlint
+    if: always() && (needs.commitlint.result == 'success' || needs.commitlint.result == 'skipped')
     uses: ./.github/workflows/test.yml
 
   goreleaser:
@@ -46,7 +58,7 @@ jobs:
         with:
           distribution: goreleaser
           version: '~> v2'
-          args: release ${{ github.ref_type != 'tag' && '--skip=publish,validate' || '' }} --release-notes release-notes.md
+          args: release ${{ github.ref_type != 'tag' && '--skip=publish,validate' || '' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -23,3 +23,22 @@ builds:
       - amd64
       - arm64
     main: ./cmd/helmsman/main.go
+
+changelog:
+  use: github
+  sort: asc
+  groups:
+    - title: Breaking Changes
+      regexp: '^.*?(\w+)(\(.+\))?!:.*$'
+      order: 0
+    - title: Features
+      regexp: '^.*?feat(\(.+\))?:.*$'
+      order: 1
+    - title: Fixes
+      regexp: '^.*?fix(\(.+\))?:.*$'
+      order: 2
+    - title: Chore
+      regexp: '^.*?(chore|docs)(\(.+\))?:.*$'
+      order: 3
+    - title: Others
+      order: 4

--- a/CONTRIBUTION.md
+++ b/CONTRIBUTION.md
@@ -20,6 +20,19 @@ make test
 
 > Helmsman v1.x supports helm v2.x only and will no longer be supported except for bug fixes and minor changes.
 
+## Commit messages
+
+This project uses [Conventional Commits](https://www.conventionalcommits.org/) to auto-generate release notes.
+
+| Type | Purpose | Example |
+|------|---------|---------|
+| `feat!:` | Breaking change | `feat!: remove deprecated API` |
+| `feat:` | New feature | `feat: add parallel release execution` |
+| `fix:` | Bug fix | `fix: helm 3.x compatibility in Dockerfile` |
+| `chore:` | Build, CI, deps, docs, infra | `chore: update goreleaser config` |
+
+Commits not matching these patterns appear under "Others" in release notes.
+
 ## Submitting pull requests
 
 - If your PR is for Helmsman v1.x, it should target the `1.x` branch.
@@ -40,17 +53,16 @@ Please provide details of the issue, versions of helmsman, helm and kubernetes a
 
 ## Releasing Helmsman
 
-Release is automated via GitHub Actions based on Git tags. [Goreleaser](https://goreleaser.com) builds and publishes binaries to GitHub Releases, while the Docker workflow builds and pushes images to GHCR.
+Release is automated via GitHub Actions based on Git tags. [Goreleaser](https://goreleaser.com) builds and publishes binaries to GitHub Releases, while the Docker workflow builds and pushes images to GHCR. Release notes are auto-generated from commit messages.
 
 To cut a release:
 
-1. Create a PR updating [release-notes.md](release-notes.md) with the new version and changelog.
-2. Get approval and merge the PR.
-3. Create and push the tag on the merged commit:
+1. Ensure commits on master follow the commit message convention.
+2. Create and push the tag:
    ```bash
    git checkout master && git pull
    git tag -a vX.Y.Z -m "vX.Y.Z"
    git push --tags
    ```
 
-The tag triggers the build pipeline which runs tests, creates the GitHub release with binaries, and pushes the Docker image.
+The tag triggers the build pipeline which runs tests, creates the GitHub release with binaries and auto-generated changelog, and pushes the Docker image.

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,9 +1,0 @@
-# v4.0.3
-
-## New feature
-
-## Fixes and improvements
-
-- Support helm v4
-
-## Changes


### PR DESCRIPTION
This PR adds autogenerated release notes with conventional commits. The goal is to reduce the releasing list to minimum. It will require contributors to follow bit of flow with commits messages, but imo results will be worth it. We'll validate commits on PRs.