### PR TITLE
fix: rely on AWS SDK error propagation for missing credentials

### DIFF
--- a/internal/aws/aws.go
+++ b/internal/aws/aws.go
@@ -15,27 +15,9 @@ import (
 // colorizer
 var style aurora.Aurora
 
-func checkCredentialsEnvVar() bool {
-	if os.Getenv("AWS_ACCESS_KEY_ID") == "" || os.Getenv("AWS_SECRET_ACCESS_KEY") == "" {
-		return false
-	} else if os.Getenv("AWS_REGION") == "" {
-
-		if os.Getenv("AWS_DEFAULT_REGION") == "" {
-			return false
-		}
-		os.Setenv("AWS_REGION", os.Getenv("AWS_DEFAULT_REGION"))
-
-	}
-	return true
-}
-
 // ReadFile reads a file from S3 bucket and saves it in a desired location.
 func ReadFile(bucketName string, filename string, outFile string, noColors bool) {
 	style = aurora.NewAurora(!noColors)
-	// Checking env vars are set to configure AWS
-	if !checkCredentialsEnvVar() {
-		log.Println("WARN: Failed to find the AWS env vars needed to configure AWS. Please make sure they are set in the environment.")
-	}
 
 	// Create Session -- use config (credentials + region) from env vars or aws profile
 	sess, err := session.NewSession()
@@ -67,11 +49,6 @@ func ReadFile(bucketName string, filename string, outFile string, noColors bool)
 // ReadSSMParam reads a value from an SSM Parameter
 func ReadSSMParam(keyname string, withDecryption bool, noColors bool) string {
 	style = aurora.NewAurora(!noColors)
-
-	// Checking env vars are set to configure AWS
-	if !checkCredentialsEnvVar() {
-		log.Println("WARN: Failed to find the AWS env vars needed to configure AWS. Please make sure they are set in the environment.")
-	}
 
 	// Create Session -- use config (credentials + region) from env vars or aws profile
 	sess, err := session.NewSession()

--- a/internal/aws/aws_test.go
+++ b/internal/aws/aws_test.go
@@ -1,0 +1,76 @@
+package aws
+
+import (
+	"flag"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+)
+
+var _ = flag.String("f", "", "") // Accept -f flag from Makefile
+
+// Verify AWS SDK returns an error when no valid credentials are found.
+func TestS3DownloadFailsWithoutCredentials(t *testing.T) {
+	// Clear AWS-related env vars and restore them later
+	envVars := []string{
+		"AWS_ACCESS_KEY_ID",
+		"AWS_SECRET_ACCESS_KEY",
+		"AWS_SESSION_TOKEN",
+		"AWS_PROFILE",
+		"AWS_SHARED_CREDENTIALS_FILE",
+		"AWS_CONFIG_FILE",
+	}
+	saved := make(map[string]string)
+	for _, v := range envVars {
+		saved[v] = os.Getenv(v)
+		os.Unsetenv(v)
+	}
+	defer func() {
+		for k, v := range saved {
+			if v != "" {
+				os.Setenv(k, v)
+			}
+		}
+	}()
+
+	sess, err := session.NewSession(&aws.Config{
+		Region: aws.String("us-east-1"),
+		Credentials: credentials.NewCredentials(&credentials.ChainProvider{
+			Providers: []credentials.Provider{
+				&credentials.EnvProvider{},
+				&credentials.SharedCredentialsProvider{Filename: "/nonexistent", Profile: "nonexistent"},
+			},
+			VerboseErrors: true,
+		}),
+	})
+	if err != nil {
+		t.Fatalf("session creation failed: %v", err)
+	}
+
+	downloader := s3manager.NewDownloader(sess)
+	_, err = downloader.Download(&fakeWriterAt{}, &s3.GetObjectInput{
+		Bucket: aws.String("test-bucket"),
+		Key:    aws.String("test-key"),
+	})
+
+	if err == nil {
+		t.Fatal("expected error when no credentials available, got nil")
+	}
+
+	errMsg := err.Error()
+	if !strings.Contains(errMsg, "NoCredentialProviders") {
+		t.Errorf("expected NoCredentialProviders error, got: %v", err)
+	}
+}
+
+type fakeWriterAt struct{}
+
+func (f *fakeWriterAt) WriteAt(p []byte, off int64) (n int, err error) {
+	return len(p), nil
+}


### PR DESCRIPTION
Should fix #975 

I think we can rely on error propagation from AWS SDK instead of upfront requirements check, see https://pkg.go.dev/github.com/aws/aws-sdk-go/aws/credentials#pkg-variables `ErrNoValidProvidersFoundInChain`.
Added simple test to make sure any error is propagated to cover this case. 