### PR TITLE
chore: disable body-max-line-length commitlint rule

### DIFF
--- a/.commitlintrc.yaml
+++ b/.commitlintrc.yaml
@@ -5,3 +5,5 @@ rules:
     - 2
     - always
     - [feat, fix, chore]
+  body-max-line-length:
+    - 0


### PR DESCRIPTION
Allows dependabot PRs to pass commitlint. The auto-generated commit bodies contain URLs that exceed the 100-character default limit.

Should allow #993 to pass checks. 